### PR TITLE
Enable topology description to have more than 9 sub-topologies

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,7 +21,7 @@ function convertTopoToDot(topo) {
 
 	// dirty but quick parsing
 	lines.forEach(line => {
-		var sub = /Sub-topology: (.)/;
+		var sub = /Sub-topology: ([0-9]*)/;
 		var match = sub.exec(line);
 
 		if (match) {


### PR DESCRIPTION
Given a description with sub-topology number > 9, it only takes first char into account.
For instance 19 => 1.

With this patch, you can use any number of sub-topologies.