### PR TITLE
Allow passing topology as base64-encoded URL hash

### DIFF
--- a/main.js
+++ b/main.js
@@ -256,6 +256,20 @@ function scheduleUpdate() {
 }
 
 // startup
-var topo = sessionStorage.getItem(STORAGE_KEY);
+var topo;
+
+if (window.location.hash.length > 1) {
+	try {
+		topo = atob(window.location.hash.substr(1));
+	} catch {
+		console.log("Can not read topo from url hash");
+		window.location.hash = "";
+	}
+}
+
+if (!topo) {
+	topo = sessionStorage.getItem(STORAGE_KEY);
+}
+
 if (topo) input.value = topo;
 update();


### PR DESCRIPTION
This allows passing a topology as base64-encoded URL hash.

Example:

`https://zz85.github.io/kafka-streams-viz/#ClRvcG9sb2dpZXM6CiAgIFN1Yi10b3BvbG9neTogMAogICAgU291cmNlOiBLU1RSRUFNLVNPVVJDRS0wMDAwMDAwMDAwICh0b3BpY3M6IFtudW1iZXJpbmcucHJpdmF0ZS5kYi5ubXNkLnBkYXRhXSkKICAgICAgLS0+IEtTVFJFQU0tTUFQVkFMVUVTLTAwMDAwMDAwMDEKICAgIFByb2Nlc3NvcjogS1NUUkVBTS1NQVBWQUxVRVMtMDAwMDAwMDAwMSAoc3RvcmVzOiBbXSkKICAgICAgLS0+IEtTVFJFQU0tRk9SRUFDSC0wMDAwMDAwMDAyCiAgICAgIDwtLSBLU1RSRUFNLVNPVVJDRS0wMDAwMDAwMDAwCiAgICBQcm9jZXNzb3I6IEtTVFJFQU0tRk9SRUFDSC0wMDAwMDAwMDAyIChzdG9yZXM6IFtdKQogICAgICAtLT4gbm9uZQogICAgICA8LS0gS1NUUkVBTS1NQVBWQUxVRVMtMDAwMDAwMDAwMQ==`