### PR TITLE
Draw lines FROM stores to joins, rather than FROM joins to stores

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,7 +61,12 @@ function convertTopoToDot(topo) {
 					topics.add(linkedName);
 				}
 				else if (type === 'stores') {
-					outside.push(`"${entityName}" -> "${linkedName}";`);
+					if (entityName.includes("JOIN")) {
+						outside.push(`"${linkedName}" -> "${entityName}";`);
+					} else {
+						outside.push(`"${entityName}" -> "${linkedName}";`);
+					}
+
 					stores.add(linkedName);
 				}
 			});


### PR DESCRIPTION
This draws the arrow from the store to the JOIN stream processing step, rather than vice versa. This matches the actual flow of execution, where the values from the store may influence downstream messages, but the JOIN itself does not update the store.