### PR TITLE
Add white background to base rectangle to make output image readable

### DIFF
--- a/main.js
+++ b/main.js
@@ -144,17 +144,23 @@ function update() {
 	}
 }
 
+function nullIfNone(attribute) {
+	return attribute === 'none' ? null : attribute;
+}
+
 /**
  * The following part can be removed when rough.js adds support for rendering svgs.
  */
 
 function getFillStroke(child) {
-	var fill = child.getAttribute('fill');
-	var stroke = child.getAttribute('stroke');
+	var fill = nullIfNone(child.getAttribute('fill'));
+	var stroke = nullIfNone(child.getAttribute('stroke'));
+	var isBaseRectangle = child.nodeName === 'polygon' && child.parentNode.id === 'graph0';
 
 	return {
-		fill: fill === 'none' ? null : fill,
-		stroke: stroke === 'none' ? null : stroke
+		fill: isBaseRectangle ? 'white' : fill,
+		fillStyle: isBaseRectangle ? 'solid' : 'hachure',
+		stroke: stroke
 	};
 }
 


### PR DESCRIPTION
This adds a white, filled background to the base rectangle, so that when you save the resulting image as a PNG, the results are not shaded by grey hachure throughout. This improves readability and shareability significantly.