### PR TITLE
Prevent regex greedy capture from eating too much.

### DIFF
--- a/main.js
+++ b/main.js
@@ -230,19 +230,19 @@ function traverseSvgToRough(child) {
 		ctx.save();
 
 		if (transform) {
-	  		var scale = /scale\((.*)\)/.exec(transform);
+	  		var scale = /scale\(([^)]*)\)/.exec(transform);
 	  		if (scale) {
 				var args = scale[1].split(' ').map(parseFloat);
 				ctx.scale(...args);
 	  		}
 
-			var rotate = /rotate\((.*)\)/.exec(transform);
+			var rotate = /rotate\(([^)]*)\)/.exec(transform);
 			if (rotate) {
 				var args = rotate[1].split(' ').map(parseFloat);
 				ctx.rotate(...args);
 			}
 
-			var translate = /translate\((.*)\)/.exec(transform);
+			var translate = /translate\(([^)]*)\)/.exec(transform);
 			if (translate) {
 				var args = translate[1].split(' ').map(parseFloat);
 				ctx.translate(...args);


### PR DESCRIPTION
The regex was eating everything up to the final closing paren, including from other svg transform commands when there are multiples, leading to args that were NaN values and causing an "Overload resolution failed" exception in Chrome/V8 when trying to call e.g. CanvasRenderingContext2D.scale() etc.  Fix is to limit the regex to any non-closing paren char when parsing the transform command.